### PR TITLE
refactor: Apply media queries to partner description boxes

### DIFF
--- a/components/SectionPartners.tsx
+++ b/components/SectionPartners.tsx
@@ -78,12 +78,12 @@ function	Partners(): ReactElement {
 							custom={i % 3}
 							initial={'initial'}
 							whileInView={'enter'}
-							className={'flex h-66 flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6'}
+							className={'flex flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6 sm:h-[16.5rem] md:h-[21.5rem] lg:h-[18.5rem]'}
 							variants={variants}>
 							<div className={'min-h-10 max-height-10 mb-5'}>
 								{partner.logo}
 							</div>
-							<div className={'min-h-full space-y-2'}>
+							<div className={'h-full space-y-2'}>
 								<b className={'text-lg'}>{partner.name}</b>
 								<p>{partner.description}</p>
 							</div>

--- a/components/icons/partners/LogoPhuture.tsx
+++ b/components/icons/partners/LogoPhuture.tsx
@@ -15,7 +15,7 @@ function	LogoPhuture(props: TLogo): ReactElement {
 	):(
 		<Image
 			style={{
-				padding:'3px'
+				paddingTop:'10px'
 			}}
 			width={60}
 			height={33}

--- a/components/icons/partners/LogoWido.tsx
+++ b/components/icons/partners/LogoWido.tsx
@@ -14,6 +14,9 @@ function	LogoWido(props: TLogo): ReactElement {
 			src={'https://raw.githubusercontent.com/yearn/yearn-assets/d37bb4f2dd42f337e9ddf8dcbbb608cc0f2cdd5f/icons/protocols/wido/logo.svg'}/>
 	):(
 		<Image
+			style={{
+				paddingTop:'3px'
+			}}
 			width={45}
 			height={37}
 			alt={'wido logo'}


### PR DESCRIPTION
## Description

This PR has the purpose to adjust the size of the partner boxes in the main page, currently the description is overflowing when the available screen size decreases (see image below).

To address this I applied media queries to improve appearance and the user experience on different screen sizes. 

Extra: Adjust the value of the padding attribute for two logos to improve the distribution between the title and the text. When compared to the other boxes, there is a very little mismatch (see image below).

## Motivation and Context

The intention after applying media queries is to improve the appearance of main page.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources (if appropriate):

The left image shows the overflow, the right one shows the result after the change.
<img width="1366" alt="Description-boxes" src="https://user-images.githubusercontent.com/104786213/232747786-7f7b3025-a9ec-469a-8a79-bf45c98f3aa1.png">


The upper image shows the small mismatch, the lower image shows the result after the adjustment.
<img width="705" alt="Adjust-css-logo" src="https://user-images.githubusercontent.com/104786213/232747819-c9069155-2e78-4c71-aa20-383f4850773c.png">

