### PR TITLE
fix: Prevent crash when data availability differs across chains

### DIFF
--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -56,13 +56,16 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 				}else {
 					const _currentPayout = dailyPayoutTotal.data.feePayout;
 					const payoutDiff = _currentPayout - lastPayout;
-					if(payoutDiff > 0){
-						lastPayout = _currentPayout;
-						// Distinction by address required as some partners have equivalent asset vaults on the same network
-						// not separation this way causes later instances of the asset to override values for the first instances
-						_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: payoutDiff}};
-					} else {
-						_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: 0}};
+
+					if(_data[idx]){
+						if(payoutDiff > 0){
+							lastPayout = _currentPayout;
+							// Distinction by address required as some partners have equivalent asset vaults on the same network
+							// not separation this way causes later instances of the asset to override values for the first instances
+							_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: payoutDiff}};
+						} else {
+							_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: 0}};
+						}
 					}
 				}
 			});
@@ -89,12 +92,14 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 			asset.forEach((dataPoint, i): void => {
 				const {token} = dataPoint;
 				const {balanceTVL} = dataPoint.data;
-				const {totalTVL} = wrapperTotals[i].data;
+				const {totalTVL} = wrapperTotals[i] ? wrapperTotals[i].data: {totalTVL: 0};
 				const _percent = totalTVL === 0 ? 0 : +formatAmount((balanceTVL / totalTVL) * 100, 0, 4).slice(0, -1);
 
-				// Distinction by address required as some partners have equivalent asset vaults on the same network
-				// not separation this way causes later instances of the asset to override values for the first instances
-				_data[i] = {..._data[i], data: {..._data[i].data, [`${token}_${network}_${address}`]: _percent}};
+				if(_data[i]){
+					// Distinction by address required as some partners have equivalent asset vaults on the same network
+					// not separation this way causes later instances of the asset to override values for the first instances
+					_data[i] = {..._data[i], data: {..._data[i].data, [`${token}_${network}_${address}`]: _percent}};
+				}
 			});
 		});
 

--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -103,7 +103,7 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 			});
 		});
 
-		return _data;
+		return _data.filter((bar): boolean => Object.keys(bar.data).length > 0);
 
 	}, [wrapperTotals, balanceTVLs]);
 	


### PR DESCRIPTION
## Description

Partners with vaults on both ETH and FTM experienced crashes due to incomplete data for ETH being available. These changes add conditions or filters to prevent these errors from crashing the dashboards.
 
crashes observed for: Ledger, Alchemix, and Abracadabra. Spool also had a crash for a different but related reason that these changes also fix. 

Extra: Fixed separate crash when viewing the tooltip for the last item in Aggregate Wrapper Balance chart. This error was also caused by incomplete data for partners with vaults on both ETH and  FTM. Crashes observed for: Abracadabra, Alchemix, Tempus


## Motivation and Context

Dashboards crashes have been observed for a subset of partners after recent issues with data availability for our Ethereum node. These changes address usability issues for these partners by adding conditions to avoiding crashes.

## How Has This Been Tested?

Manually entering all dashboards to ensure crashes on loading of Overview tab no longer take place for any partners.

## Resources

N/A