### PR TITLE
fix: Prevent crashes due to data availability and UI improvements

### DIFF
--- a/components/SectionPartners.tsx
+++ b/components/SectionPartners.tsx
@@ -78,12 +78,12 @@ function	Partners(): ReactElement {
 							custom={i % 3}
 							initial={'initial'}
 							whileInView={'enter'}
-							className={'flex h-66 flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6'}
+							className={'flex flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6 sm:h-[16.5rem] md:h-[21.5rem] lg:h-[18.5rem]'}
 							variants={variants}>
 							<div className={'min-h-10 max-height-10 mb-5'}>
 								{partner.logo}
 							</div>
-							<div className={'min-h-full space-y-2'}>
+							<div className={'h-full space-y-2'}>
 								<b className={'text-lg'}>{partner.name}</b>
 								<p>{partner.description}</p>
 							</div>

--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -56,13 +56,16 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 				}else {
 					const _currentPayout = dailyPayoutTotal.data.feePayout;
 					const payoutDiff = _currentPayout - lastPayout;
-					if(payoutDiff > 0){
-						lastPayout = _currentPayout;
-						// Distinction by address required as some partners have equivalent asset vaults on the same network
-						// not separation this way causes later instances of the asset to override values for the first instances
-						_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: payoutDiff}};
-					} else {
-						_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: 0}};
+
+					if(_data[idx]){
+						if(payoutDiff > 0){
+							lastPayout = _currentPayout;
+							// Distinction by address required as some partners have equivalent asset vaults on the same network
+							// not separation this way causes later instances of the asset to override values for the first instances
+							_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: payoutDiff}};
+						} else {
+							_data[idx] = {..._data[idx], data: {..._data[idx].data, [assetId]: 0}};
+						}
 					}
 				}
 			});
@@ -89,16 +92,18 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 			asset.forEach((dataPoint, i): void => {
 				const {token} = dataPoint;
 				const {balanceTVL} = dataPoint.data;
-				const {totalTVL} = wrapperTotals[i].data;
+				const {totalTVL} = wrapperTotals[i] ? wrapperTotals[i].data: {totalTVL: 0};
 				const _percent = totalTVL === 0 ? 0 : +formatAmount((balanceTVL / totalTVL) * 100, 0, 4).slice(0, -1);
 
-				// Distinction by address required as some partners have equivalent asset vaults on the same network
-				// not separation this way causes later instances of the asset to override values for the first instances
-				_data[i] = {..._data[i], data: {..._data[i].data, [`${token}_${network}_${address}`]: _percent}};
+				if(_data[i]){
+					// Distinction by address required as some partners have equivalent asset vaults on the same network
+					// not separation this way causes later instances of the asset to override values for the first instances
+					_data[i] = {..._data[i], data: {..._data[i].data, [`${token}_${network}_${address}`]: _percent}};
+				}
 			});
 		});
 
-		return _data;
+		return _data.filter((bar): boolean => Object.keys(bar.data).length > 0);
 
 	}, [wrapperTotals, balanceTVLs]);
 	

--- a/components/icons/partners/LogoPhuture.tsx
+++ b/components/icons/partners/LogoPhuture.tsx
@@ -15,7 +15,7 @@ function	LogoPhuture(props: TLogo): ReactElement {
 	):(
 		<Image
 			style={{
-				padding:'3px'
+				paddingTop:'10px'
 			}}
 			width={60}
 			height={33}

--- a/components/icons/partners/LogoWido.tsx
+++ b/components/icons/partners/LogoWido.tsx
@@ -14,6 +14,9 @@ function	LogoWido(props: TLogo): ReactElement {
 			src={'https://raw.githubusercontent.com/yearn/yearn-assets/d37bb4f2dd42f337e9ddf8dcbbb608cc0f2cdd5f/icons/protocols/wido/logo.svg'}/>
 	):(
 		<Image
+			style={{
+				paddingTop:'3px'
+			}}
 			width={45}
 			height={37}
 			alt={'wido logo'}


### PR DESCRIPTION
## Description

This PR primarily addresses 3 related types of dashboard crashes that have been observed for partners that have vaults on both ETH and FTM. More details here https://github.com/yearn/yPartners/pull/171

* All relevant changes for this can be found in: components/graphs/OverviewChart.tsx

Additionally it includes changes to improve the UI related to displaying partner descriptions on the home page. More details here https://github.com/yearn/yPartners/pull/170

## Motivation and Context

Errors occurred and were handled. Potential UI improvement were seen and were made. This is all part of our continuing support and improvement of yPartners.

## How Has This Been Tested?

UI Improvements to homepage were manually verified. Prevention is dashboard crashes was also isolated to a few partners, corrected, then manually verified to be working correctly after changes. 

## Resources

See PRs linked above. 