### PR TITLE
refactor: Remove unnecessary react imports

### DIFF
--- a/components/B2BMeme.tsx
+++ b/components/B2BMeme.tsx
@@ -1,4 +1,3 @@
-import	React		from	'react';
 import	{motion}					from	'framer-motion';
 
 import type {ReactElement, SVGProps} from 'react';

--- a/components/SectionPartners.tsx
+++ b/components/SectionPartners.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import {PARTNERS} from 'utils/b2b/Partners';
 import useSWR from 'swr';
 import {motion} from 'framer-motion';

--- a/components/SectionTargets.tsx
+++ b/components/SectionTargets.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import IconForDevelopers from 'components/icons/IconForDevelopers';
 import IconForInstitutions from 'components/icons/IconForInstitutions';
 import IconForProtocols from 'components/icons/IconForProtocols';

--- a/components/charts/Bar.tsx
+++ b/components/charts/Bar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {formatYAxis} from 'utils/b2b/Chart';
 

--- a/components/charts/Chart.tsx
+++ b/components/charts/Chart.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Bar from './Bar';
 import ChartLegend from './ChartLegend';
 import Composed from './Composed';

--- a/components/charts/ChartLegend.tsx
+++ b/components/charts/ChartLegend.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type {ReactElement} from 'react';
 import type {TLegendItem} from 'types/chart';
 

--- a/components/charts/Composed.tsx
+++ b/components/charts/Composed.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import CustomTooltip from 'components/charts/CustomTooltip';
 import {Bar, Cell, ComposedChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {formatYAxis} from 'utils/b2b/Chart';

--- a/components/charts/CustomTooltip.tsx
+++ b/components/charts/CustomTooltip.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 
 import type {ReactElement} from 'react';

--- a/components/charts/Stacked.tsx
+++ b/components/charts/Stacked.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {formatYAxis} from 'utils/b2b/Chart';
 

--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import OverviewChart from 'components/graphs/OverviewChart';
 import IconChevronDown from 'components/icons/IconChevronDown';
 import dayjs, {extend, unix} from 'dayjs';

--- a/components/dashboard/SummaryMetrics.tsx
+++ b/components/dashboard/SummaryMetrics.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 
 import type {ReactElement} from 'react';

--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -1,4 +1,4 @@
-import	React, {useMemo, useState}	from	'react';
+import {useMemo, useState}	from	'react';
 import Chart from 'components/charts/Chart';
 import {NETWORK_LABELS} from 'utils/b2b';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';

--- a/components/graphs/VaultChart.tsx
+++ b/components/graphs/VaultChart.tsx
@@ -1,4 +1,4 @@
-import	React, {useMemo}		from	'react';
+import {useMemo}		from	'react';
 import {truncateHex} from '@yearn-finance/web-lib/utils/address';
 
 import Chart from '../charts/Chart';

--- a/components/icons/IconChevronDown.tsx
+++ b/components/icons/IconChevronDown.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	IconChevronDown(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/IconForDevelopers.tsx
+++ b/components/icons/IconForDevelopers.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	IconForDevelopers(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/IconForInstitutions.tsx
+++ b/components/icons/IconForInstitutions.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	IconForInstitutions(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/IconForProtocols.tsx
+++ b/components/icons/IconForProtocols.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	IconForProtocols(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/LogoYearn.tsx
+++ b/components/icons/LogoYearn.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	LogoYearn(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/partners/DefaultLogo.tsx
+++ b/components/icons/partners/DefaultLogo.tsx
@@ -1,5 +1,3 @@
-import	React		from	'react';
-
 import type {ReactElement, SVGProps} from 'react';
 
 function	DefaultLogo(props: SVGProps<SVGSVGElement>): ReactElement {

--- a/components/icons/partners/LogoAkropolis.tsx
+++ b/components/icons/partners/LogoAkropolis.tsx
@@ -1,4 +1,3 @@
-
 import 	Image	from	'next/image';
 
 import type {ReactElement, SVGProps} from 'react';

--- a/contexts/useAuth.tsx
+++ b/contexts/useAuth.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, memo, useContext, useState} from 'react';
+import {createContext, memo, useContext, useState} from 'react';
 
 import type {ReactElement} from 'react';
 

--- a/contexts/usePartner.tsx
+++ b/contexts/usePartner.tsx
@@ -1,4 +1,4 @@
-import	React, {createContext, useContext, useMemo}	from 'react';
+import {createContext, useContext, useMemo}	from 'react';
 import {useYearn} from 'contexts/useYearn';
 import {NETWORK_CHAINID} from 'utils/b2b';
 import {SHAREABLE_ADDRESSES} from 'utils/b2b/Partners';

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, memo, useContext, useMemo} from 'react';
+import {createContext, memo, useContext, useMemo} from 'react';
 import useSWR from 'swr';
 import {useSettings} from '@yearn-finance/web-lib/contexts/useSettings';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import {useRouter} from 'next/router';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Document, {Head, Html, Main, NextScript} from 'next/document';
 
 import type {DocumentContext, DocumentInitialProps} from 'next/document';

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -1,5 +1,4 @@
-
-import React, {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {DashboardTabsWrapper} from 'components/dashboard/DashboardTabsWrapper';
 import {PartnerContextApp, usePartner} from 'contexts/usePartner';
 import useWindowDimensions from 'hooks/useWindowDimensions';

--- a/pages/disclaimer.tsx
+++ b/pages/disclaimer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Link from 'next/link';
 import {Card} from '@yearn-finance/web-lib/components/Card';
 import Cross from '@yearn-finance/web-lib/icons/IconCross';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Link from 'next/link';
 import B2BMeme from 'components/B2BMeme';
 import SectionPartner from 'components/SectionPartners';

--- a/pages/learn-more.tsx
+++ b/pages/learn-more.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import IconLinkOut from '@yearn-finance/web-lib/icons/IconLinkOut';
 
 import type {ReactElement} from 'react';

--- a/pages/team-up.tsx
+++ b/pages/team-up.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import IconLinkOut from '@yearn-finance/web-lib/icons/IconLinkOut';
 
 import type {ReactElement} from 'react';


### PR DESCRIPTION
## Description

This PR has the purpose update react imports in this repo.

In these cases:

       import React, {useMemo, useState} from 'react';

The first 'React' was removed leaving only the hooks or complements:

    import {useMemo, useState} from 'react';

and lines that only imported React from 'react', they were removed.

## Related Issue

N/A

## Motivation and Context

The motivation by removing unnecessary imports is to keep the code as clean as possible.  Directly importing react used to be required but for a while now it hasn't been. 

## How Has This Been Tested?

After making the changes I ran 'yarn dev' and confirmed that there was no error or loss of functionality, everything appeared as expected.

## Resources

Reference: [The New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)